### PR TITLE
moved to http

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ config_staging.json
 config.json
 glock
 *.exe
+
+*.iml
+.idea/

--- a/README.md
+++ b/README.md
@@ -3,47 +3,96 @@ glock
 
 ## Configuration
 
-Configuration is not required unless you want to change some things. Config file should be called `config.json` and can contain the following:
-
-TODO: port, authentication, etc.
-
-## Commands
-
-### LOCK command
+Configuration is not required unless you want to change some things. Config file should be called `config.json` 
+and can contain the following:
 
 ```json
 {
-  "command": "lock",
+  "Authentication": {
+    "mytoken": true,
+    "anothertoken": true
+  },
+  "Port": 45625
+}
+```
+
+TODO: logging, locklimit, authentication -> list [in config only]
+
+## Authentication
+
+If desired behavior, client authentication should be passed as such:
+
+In the header for the HTTP request should exist a field of the form:
+
+`Authorization: OAuth your_token_here`
+
+## Commands
+
+### PING command
+
+Issue PING to:
+
+```
+GET glockserver:port/ping
+```
+
+### LOCK command
+
+Issue LOCK to:
+
+```
+PUT glockserver:port/lock
+```
+
+With `application/json` body:
+
+```json
+{
   "key": "YOUR KEY",
   "timeout": "TIMEOUT VALUE",
   "size": "NUMBER OF CONCURRENT LOCKS ON THIS KEY"
 }
 ```
 
-Response:
+Success response:
 
 ```json
 {
+  "msg": "Locked",
   "id": "unique lock id"
 }
 ```
-
-
-
 ### UNLOCK command
+
+Issue UNLOCK to:
+
+```
+PUT glockserver:port/unlock
+```
+
+With `application/json` body:
 
 ```json
 {
-  "command": "unlock",
   "key": "YOUR KEY",
   "id": "ID returned from the LOCK command"
 }
 ```
 
-Response:
+Successful unlock response:
 
 ```json
 {
-
+  "msg": "Unlocked"
 }
 ```
+
+If lock does not exist for given id or lock has already timed out, your request
+may still succeed but will return a response of the form:
+
+```json
+{
+  "msg": "Not unlocked"
+}
+```
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,49 @@
 glock
 =====
 
-Boom
+## Configuration
+
+Configuration is not required unless you want to change some things. Config file should be called `config.json` and can contain the following:
+
+TODO: port, authentication, etc.
+
+## Commands
+
+### LOCK command
+
+```json
+{
+  "command": "lock",
+  "key": "YOUR KEY",
+  "timeout": "TIMEOUT VALUE",
+  "size": "NUMBER OF CONCURRENT LOCKS ON THIS KEY"
+}
+```
+
+Response:
+
+```json
+{
+  "id": "unique lock id"
+}
+```
+
+
+
+### UNLOCK command
+
+```json
+{
+  "command": "unlock",
+  "key": "YOUR KEY",
+  "id": "ID returned from the LOCK command"
+}
+```
+
+Response:
+
+```json
+{
+
+}
+```

--- a/client/client.go
+++ b/client/client.go
@@ -8,11 +8,11 @@ import (
 	"sync/atomic"
 	"time"
 
+	"encoding/json"
+	"fmt"
 	"github.com/iron-io/golog"
 	"github.com/stathat/consistent"
-	"encoding/json"
 	"io"
-	"fmt"
 )
 
 type connectionError struct {
@@ -59,23 +59,14 @@ type Request struct {
 }
 
 type Response struct {
-	Code  int
-	Msg   string
-	Id    int64
-	Error error
+	Code int
+	Msg  string
+	Id   int64
 }
 
-// func (c *Client) ClosePool() error {
-// 	size := len(c.connectionPool)
-// 	for x := 0; x < size; x++ {
-// 		connection := <-c.connectionPool
-// 		err := connection.Close()
-// 		if err != nil {
-// 			return err
-// 		}
-// 	}
-// 	return nil
-// }
+func (r *Response) Error() string {
+	return fmt.Sprintf("%v: %v", r.Code, r.Msg)
+}
 
 func (c *Client) Size() int {
 	var size int
@@ -304,7 +295,12 @@ func (c *connection) readResponse() (*Response, error) {
 		golog.Errorln(err)
 		return nil, err
 	}
-	return &response, nil
+	if response.Code == 200 {
+		return &response, nil
+	} else {
+		return nil, &response
+	}
+
 }
 
 func (c *connection) dial() error {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -127,7 +127,7 @@ func TestConnectionDrop(t *testing.T) {
 
 }
 
-// // This is used to simulate dropped out or bad connections in the connection pool
+// This is used to simulate dropped out or bad connections in the connection pool
 func (c *Client) testClose() {
 	for server, pool := range c.connectionPools {
 		fmt.Println(server)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -79,7 +79,7 @@ func TestLockUnlock(t *testing.T) {
 }
 
 func TestLockLimit(t *testing.T) {
-	client1, err := NewClient(glockServers, 1000, "", "")
+	client1, err := NewClient(glockServers, 2000, "", "")
 	if err != nil {
 		t.Error("Unexpected error creating new client: ", err)
 	}
@@ -87,16 +87,15 @@ func TestLockLimit(t *testing.T) {
 	for i := 0; i < 1000; i++ {
 		go client1.Lock(lockKey, 10*time.Second)
 	}
-	time.Sleep(5 * time.Second)
+	time.Sleep(1 * time.Second)
+	fmt.Println("Slept for a second, expect to see error below")
 
-	fmt.Println("we should expect lock error below")
 	_, err = client1.Lock(lockKey, 10*time.Second)
+	fmt.Println("returned from lock", err)
 	if err == nil {
 		t.Error("Should have rate limited the 1001 connection")
-	}
-
-	if err, ok := err.(*CapacityError); !ok {
-		t.Error("Expected capacity error got: ", err)
+	} else {
+		fmt.Println("Got an expected error: ", err)
 	}
 }
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -34,7 +34,7 @@ func TestPingPong(t *testing.T) {
 }
 
 func TestLockUnlock(t *testing.T) {
-	client1, err := NewClient(glockServers, 10, "test_username", "test_password")
+	client1, err := NewClient(glockServers, 10, "", "")
 	if err != nil {
 		t.Error("Unexpected new client error: ", err)
 	}
@@ -79,7 +79,7 @@ func TestLockUnlock(t *testing.T) {
 }
 
 func TestLockLimit(t *testing.T) {
-	client1, err := NewClient(glockServers, 1000, "test_username", "test_password")
+	client1, err := NewClient(glockServers, 1000, "", "")
 	if err != nil {
 		t.Error("Unexpected error creating new client: ", err)
 	}
@@ -101,7 +101,7 @@ func TestLockLimit(t *testing.T) {
 }
 
 func TestConnectionDrop(t *testing.T) {
-	client1, err := NewClient(glockServers, 10, "test_username", "test_password")
+	client1, err := NewClient(glockServers, 10, "", "")
 	if err != nil {
 		t.Error("Unexpected new client error: ", err)
 	}
@@ -142,7 +142,7 @@ func (c *Client) testClose() {
 }
 
 func TestConcurrency(t *testing.T) {
-	client1, err := NewClient(glockServers, 500, "test_username", "test_password")
+	client1, err := NewClient(glockServers, 500, "", "")
 	if err != nil {
 		t.Error("Unexpected new client error: ", err)
 	}
@@ -182,7 +182,7 @@ func TestConcurrency(t *testing.T) {
 }
 
 func TestServerDrop(t *testing.T) {
-	client1, err := NewClient(glockServers, 500, "test_username", "test_password")
+	client1, err := NewClient(glockServers, 500, "", "")
 	if err != nil {
 		t.Error("Unexpected new client error: ", err)
 	}

--- a/glock.go
+++ b/glock.go
@@ -42,6 +42,7 @@ func (l *timeoutLock) lock() bool {
 		for {
 			count := atomic.LoadInt64(&l.lockCount)
 			if count >= config.LockLimit {
+				golog.Infoln("Reached limit")
 				return false
 			}
 
@@ -246,6 +247,7 @@ func lock(conn net.Conn, request Request) {
 	}
 
 	if !lock.lock() {
+		golog.Infoln("ErrResponse here")
 		errResponse(conn, errLockAtCapacityResponse, nil)
 		return
 	}

--- a/glock.go
+++ b/glock.go
@@ -7,22 +7,20 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
-	"net"
-	"runtime/debug"
-	"strconv"
+	"net/http"
+	"strings"
 	"sync"
 
-	"io"
-
+	"github.com/gorilla/mux"
 	"github.com/iron-io/glock/protocol"
 	"github.com/iron-io/glock/semaphore"
 	"github.com/iron-io/golog"
 )
 
 type GlockConfig struct {
-	Port           int               `json:"port"`
-	LockLimit      int64             `json:"lock_limit"`
-	Authentication map[string]string `json:"authentication"`
+	Port           int             `json:"port"`
+	LockLimit      int64           `json:"lock_limit"`
+	Authentication map[string]bool `json:"authentication"`
 	Logging        LoggingConfig
 }
 
@@ -38,8 +36,21 @@ type timeoutLock struct {
 	lockCount int64
 }
 
-var config GlockConfig
-var glock *semaphore.Glock
+var (
+	config GlockConfig
+	glock  *semaphore.Glock
+
+	unlockedResponse    = protocol.Response{Code: 200, Msg: "Unlocked"}
+	notUnlockedResponse = protocol.Response{Code: 200, Msg: "Not unlocked"}
+	pongResponse        = protocol.Response{Code: 200, Msg: "Pong"}
+
+	errBadFormatResponse      = protocol.Response{Code: 400, Msg: "Invalid parameters for command"}
+	errUnauthorizedResponse   = protocol.Response{Code: 401, Msg: "Unauthorized"}
+	errLockNotFoundResponse   = protocol.Response{Code: 404, Msg: "Lock not found"}
+	errUnknownCommandResponse = protocol.Response{Code: 405, Msg: "Unknown command"}
+	errInternalServerResponse = protocol.Response{Code: 500, Msg: "Internal server error"}
+	errLockAtCapacityResponse = protocol.Response{Code: 503, Msg: "Lock at capacity"}
+)
 
 func main() {
 	var port int
@@ -62,11 +73,6 @@ func main() {
 		config.Logging.Level = "debug"
 	}
 
-	listener, err := net.Listen("tcp", ":"+strconv.Itoa(config.Port))
-	if err != nil {
-		log.Fatalln("error listening", err)
-	}
-
 	if logLocal {
 		config.Logging.To = ""
 		config.Logging.Prefix = ""
@@ -78,41 +84,60 @@ func main() {
 
 	glock = semaphore.NewGlock()
 
-	for {
-		conn, err := listener.Accept()
+	r := mux.NewRouter()
+	r.NotFoundHandler = http.HandlerFunc(notCommand)
+
+	r.HandleFunc("/ping", ping).Methods("GET")
+	r.HandleFunc("/lock", handle(lock)).Methods("PUT")
+	r.HandleFunc("/unlock", handle(unlock)).Methods("PUT")
+
+	http.Handle("/", r)
+	http.ListenAndServe(fmt.Sprintf(":%d", config.Port), nil)
+}
+
+func handle(hfunc func(http.ResponseWriter, protocol.Request)) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		golog.Infoln("Handling new connection", r)
+
+		var request protocol.Request
+		err := json.NewDecoder(bufio.NewReader(r.Body)).Decode(&request)
 		if err != nil {
-			golog.Errorln("error accepting", err)
+			errResponse(w, errBadFormatResponse, err)
 			return
 		}
-		go handleConn(conn)
+		if err := auth(r); err != nil {
+			errResponse(w, errUnauthorizedResponse, err)
+			return
+		}
+
+		hfunc(w, request)
 	}
 }
 
-var (
-	unlockedResponse    = protocol.Response{Code: 200, Msg: "Unlocked"}
-	notUnlockedResponse = protocol.Response{Code: 204, Msg: "Not unlocked"}
-	pongResponse        = protocol.Response{Code: 200, Msg: "Pong"}
-	authorizedResponse  = protocol.Response{Code: 200, Msg: "Authorized"}
-
-	errBadFormatResponse      = protocol.Response{Code: 400, Msg: "Invalid parameters for command"}
-	errUnauthorizedResponse   = protocol.Response{Code: 403, Msg: "Unauthorized"}
-	errLockNotFoundResponse   = protocol.Response{Code: 404, Msg: "Lock not found"}
-	errUnknownCommandResponse = protocol.Response{Code: 405, Msg: "Unknown command"}
-	errInternalServerResponse = protocol.Response{Code: 500, Msg: "Internal server error"}
-	errLockAtCapacityResponse = protocol.Response{Code: 503, Msg: "Lock at capacity"}
-)
-
-func authenticate(request protocol.Request) error {
+// check Authorization header for OAuth token of form:
+//  'Authorization: OAuth token_goes_here'
+func auth(request *http.Request) error {
 	if len(config.Authentication) != 0 {
-		password, ok := config.Authentication[request.Username]
-		if !ok {
-			err := fmt.Errorf("auth: User not found: %v", request.Username)
+		auth, ok := request.Header["Authorization"]
+		if !ok || len(auth) < 1 {
+			err := fmt.Errorf("auth: authentication required but not provided")
 			golog.Errorln(err)
 			return err
 		}
 
-		if password != request.Token {
-			err := fmt.Errorf("auth: Bad token for %v", request.Username)
+		fields := strings.Fields(auth[0])
+
+		if len(fields) < 2 || fields[0] != "OAuth" { // not really oauth, not sure if that level is necessary
+			err := fmt.Errorf("auth: bad auth header: %v", auth)
+			golog.Errorln(err)
+			return err
+		}
+
+		token := fields[1]
+		_, ok = config.Authentication[token]
+
+		if !ok {
+			err := fmt.Errorf("auth: Token not found: %v", token)
 			golog.Errorln(err)
 			return err
 		}
@@ -120,73 +145,17 @@ func authenticate(request protocol.Request) error {
 	return nil
 }
 
-func handleConn(conn net.Conn) {
-	defer func() {
-		conn.Close()
-		// make sure a panic doesn't take down the whole server
-		err := recover()
-		if err != nil {
-			golog.Errorf("recovered from panic: %v\n%s\n", err, debug.Stack())
-		}
-	}()
-
-	authenticated := false
-	if len(config.Authentication) == 0 {
-		authenticated = true
-	}
-	golog.Infoln("Handling new connection", conn)
-	dec := json.NewDecoder(bufio.NewReader(conn))
-	for {
-		var request protocol.Request
-		if err := dec.Decode(&request); err == io.EOF {
-			golog.Debugf("Got an EOF, breaking and closing this connection.")
-			break
-		} else if err != nil {
-			errResponse(conn, errBadFormatResponse, err)
-			continue
-		}
-
-		switch request.Command {
-		case "ping":
-			respond(conn, pongResponse)
-			golog.Debugf("PING PONG")
-			continue
-
-		case "auth":
-			err := authenticate(request)
-			if err != nil {
-				errResponse(conn, errUnauthorizedResponse, err)
-				// todo: close connection and perhaps ban IP for a bit if too many failed auths.
-				continue
-			}
-			authenticated = true
-			respond(conn, authorizedResponse)
-			continue
-
-		default:
-			if !authenticated {
-				// todo: ban IP for a bit if too many failed auths
-				errResponse(conn, errUnauthorizedResponse, nil)
-				continue
-			}
-			switch request.Command {
-			case "lock":
-				lock(conn, request)
-			case "unlock":
-				unlock(conn, request)
-
-			default:
-				errResponse(conn, errUnknownCommandResponse, nil)
-				continue
-			}
-
-		}
-	}
+func notCommand(w http.ResponseWriter, r *http.Request) {
+	errResponse(w, errUnknownCommandResponse, nil)
 }
 
-func lock(conn net.Conn, request protocol.Request) {
+func ping(w http.ResponseWriter, r *http.Request) {
+	respond(w, pongResponse)
+}
+
+func lock(w http.ResponseWriter, request protocol.Request) {
 	if request.Key == "" {
-		errResponse(conn, errBadFormatResponse, fmt.Errorf("lock command requires a key"))
+		errResponse(w, errBadFormatResponse, fmt.Errorf("lock command requires a key"))
 		return
 	}
 	key := request.Key
@@ -201,22 +170,22 @@ func lock(conn net.Conn, request protocol.Request) {
 	if id == 0 {
 		// id should not be zero
 	} else {
-		response := protocol.Response{Code: 200, Msg: "Locked", Id: id}
-		respond(conn, response)
+		response := protocol.Response{Code: 201, Msg: "Locked", Id: id}
+		respond(w, response)
 
 		golog.Debugf("P %-5d | Request:  %+v", config.Port, request)
 		golog.Debugf("P %-5d | Response: %-12s | Key:  %-15s | Id: %d", config.Port, "LOCKED", key, id)
 	}
 }
 
-func unlock(conn net.Conn, request protocol.Request) {
+func unlock(w http.ResponseWriter, request protocol.Request) {
 	if request.Key == "" {
-		errResponse(conn, errBadFormatResponse, fmt.Errorf("unlock command requires a key"))
+		errResponse(w, errBadFormatResponse, fmt.Errorf("unlock command requires a key"))
 		return
 	}
 
 	if request.Id == 0 {
-		errResponse(conn, errBadFormatResponse, fmt.Errorf("unlock command requires an id"))
+		errResponse(w, errBadFormatResponse, fmt.Errorf("unlock command requires an id"))
 		return
 	}
 
@@ -226,7 +195,7 @@ func unlock(conn net.Conn, request protocol.Request) {
 	lock, ok := glock.GetLock(key)
 
 	if !ok { // no lock found
-		errResponse(conn, errLockNotFoundResponse, nil)
+		errResponse(w, errLockNotFoundResponse, nil)
 
 		golog.Debugf("P %-5d | Request:  %+v", config.Port, request)
 		golog.Debugf(errLockNotFoundResponse.Msg, ": ", request, "| P ", config.Port)
@@ -236,12 +205,12 @@ func unlock(conn net.Conn, request protocol.Request) {
 
 	// found lock
 	if lock.Unlock(id) {
-		respond(conn, unlockedResponse)
+		respond(w, unlockedResponse)
 		golog.Debugf("P %-5d | Request:  %+v", config.Port, request)
 		golog.Debugf("P %-5d | Response: %-12s | Key:  %-15s | Id: %d", config.Port, "UNLOCKED", key, id)
 
 	} else {
-		respond(conn, notUnlockedResponse)
+		respond(w, notUnlockedResponse)
 		golog.Debugf("P %-5d | Request:  %+v", config.Port, request)
 		golog.Debugf("P %-5d | Response: %-12s | Key:  %-15s | Id: %d", config.Port, "NOT_UNLOCKED", key, id)
 	}
@@ -260,17 +229,19 @@ func LoadConfig(configFile string, config interface{}) {
 	golog.Infoln("config:", config)
 }
 
-func errResponse(conn net.Conn, response protocol.Response, err error) {
+func errResponse(w http.ResponseWriter, response protocol.Response, err error) {
 	if err != nil {
 		response.Msg = err.Error()
 	}
-	respond(conn, response)
+	respond(w, response)
 }
 
-func respond(conn net.Conn, response protocol.Response) {
+func respond(w http.ResponseWriter, response protocol.Response) {
 	b, err := json.Marshal(response)
 	if err != nil {
 		golog.Errorln("Error marshalling response:", response, err)
 	}
-	conn.Write(b)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(response.Code)
+	w.Write(b)
 }

--- a/glock_test.go
+++ b/glock_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"encoding/json"
+	"net"
+	"testing"
+	"time"
+)
+
+func newServer() net.Conn {
+	client, server := net.Pipe()
+	go handleConn(server)
+	return client
+}
+
+func send(t *testing.T, conn net.Conn, req *Request) *Response {
+	enc := json.NewEncoder(conn)
+	dec := json.NewDecoder(conn)
+	err := enc.Encode(&req)
+	if err != nil {
+		t.Fatal("unexpected encode error:", err)
+	}
+	var resp Response
+	err = dec.Decode(&resp)
+	if err != nil {
+		t.Fatal("unexpected decode error:", err)
+	}
+	return &resp
+}
+
+func checkCode(t *testing.T, code, expected int) {
+	if code != expected {
+		t.Fatalf("expected response %v, got %v", expected, code)
+	}
+}
+
+func TestLockUnlock(t *testing.T) {
+	conn := newServer()
+	defer conn.Close()
+
+	resp := send(t, conn, &Request{Command: "lock", Key: "key", Timeout: 5000})
+	checkCode(t, resp.Code, 200)
+
+	resp = send(t, conn, &Request{Command: "unlock", Key: "key", Id: resp.Id})
+	checkCode(t, resp.Code, 200)
+}
+
+func TestLockTimeout(t *testing.T) {
+	conn := newServer()
+	defer conn.Close()
+
+	resp := send(t, conn, &Request{Command: "lock", Key: "key", Timeout: 500})
+	checkCode(t, resp.Code, 200)
+
+	time.Sleep(1*time.Second)
+
+	resp = send(t, conn, &Request{Command: "unlock", Key: "key", Id: resp.Id})
+	checkCode(t, resp.Code, 204)
+}
+
+func TestLockLimit(t *testing.T) {
+	oldLimit := config.LockLimit
+	config.LockLimit = 1
+	defer func() {
+		config.LockLimit = oldLimit
+	}()
+
+	conn := newServer()
+	defer conn.Close()
+
+	resp := send(t, conn, &Request{Command: "lock", Key: "key", Timeout: 500})
+	checkCode(t, resp.Code, 200)
+
+	resp = send(t, conn, &Request{Command: "lock", Key: "key", Timeout: 500})
+	checkCode(t, resp.Code, 503)
+}

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -1,27 +1,16 @@
 package protocol
 
-import (
-	"fmt"
-)
-
 // Incoming requests
 type Request struct {
-	Command  string
-	Username string // not sure if we need a username?  A global token might be fine
-	Token    string // for authentication, set in config
-	Key      string
-	Size     int // size of the semaphore
-	Timeout  int
-	Id       int64
+	Key     string `json:"key"`
+	Size    int    `json:"size"` // size of the semaphore
+	Timeout int    `json:"timeout"`
+	Id      int64  `json:"id"`
 }
 
 // Outgoing responses
 type Response struct {
-	Code int
-	Msg  string
-	Id   int64
-}
-
-func (r *Response) Error() string {
-	return fmt.Sprintf("%v: %v", r.Code, r.Msg)
+	Code int    `json:"-"`
+	Msg  string `json:"msg"`
+	Id   int64  `json:"id,omitempty"`
 }

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -1,0 +1,27 @@
+package protocol
+
+import (
+	"fmt"
+)
+
+// Incoming requests
+type Request struct {
+	Command  string
+	Username string // not sure if we need a username?  A global token might be fine
+	Token    string // for authentication, set in config
+	Key      string
+	Size     int // size of the semaphore
+	Timeout  int
+	Id       int64
+}
+
+// Outgoing responses
+type Response struct {
+	Code int
+	Msg  string
+	Id   int64
+}
+
+func (r *Response) Error() string {
+	return fmt.Sprintf("%v: %v", r.Code, r.Msg)
+}

--- a/semaphore/semaphore.go
+++ b/semaphore/semaphore.go
@@ -1,0 +1,157 @@
+package semaphore
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+type Empty struct {
+}
+
+type Glock struct {
+	Locks     map[string]*Lock
+	LocksLock sync.RWMutex
+}
+
+func NewGlock() *Glock {
+	return &Glock{make(map[string]*Lock), sync.RWMutex{}}
+}
+
+func (g *Glock) GetOrCreateLock(key string, size int64) *Lock {
+	if l, ok := g.GetLock(key); !ok {
+		// lock not found
+		// create it
+		return g.CreateLock(key, size)
+	} else {
+		// resize lock and return
+		l.Resize(size)
+		return l
+	}
+}
+
+// lock and check if a matching lock exists
+// if it does return it
+// if not create a new lock
+// note: matching lock requires the same key and the same size; if size is different, it will be
+// replaced
+func (g *Glock) GetLock(key string) (*Lock, bool) {
+	g.LocksLock.RLock()
+	l, ok := g.Locks[key]
+	g.LocksLock.RUnlock()
+	// in most cases a lock already exists so we use a read lock
+	// to confirm that
+	return l, ok
+}
+
+func (g *Glock) CreateLock(key string, size int64) *Lock {
+	// let's acquire write lock and check again and see if someone else created one already
+	g.LocksLock.Lock()
+	if l, ok := g.Locks[key]; ok {
+		// someone created one in the meantime, let's return that
+		l.Resize(size)
+		g.LocksLock.Unlock()
+		return l
+	} else {
+		// lock still does not exist; let's create one
+		l := &Lock{Semaphore: int64(0), SemaphoreLock: sync.Mutex{}, Capacity: size, TimeoutSet: make(map[int64]bool), Id: int64(0), TimeoutSetLock: sync.Mutex{}}
+		l.Cond = sync.NewCond(&l.SemaphoreLock)
+		g.Locks[key] = l
+		g.LocksLock.Unlock()
+		return l
+	}
+	g.LocksLock.Unlock()
+	return nil
+}
+
+// note: no overflow on int64 - we will probably never get to the end of int64
+type Lock struct {
+	Semaphore      int64
+	SemaphoreLock  sync.Mutex
+	Capacity       int64
+	TimeoutSet     map[int64]bool
+	Id             int64
+	TimeoutSetLock sync.Mutex
+	Cond           *sync.Cond
+}
+
+// Blocking lock
+func (l *Lock) BLock(timeout int) int64 {
+	var lockId int64
+	l.SemaphoreLock.Lock()
+	for {
+		if l.Semaphore >= l.Capacity {
+			l.Cond.Wait()
+		} else {
+			break
+		}
+	}
+	l.Semaphore++
+	lockId = l.lock(timeout)
+	l.SemaphoreLock.Unlock()
+
+	return lockId
+}
+
+// Non Blocking lock
+func (l *Lock) NLock(timeout int) int64 {
+	l.SemaphoreLock.Lock()
+	if l.Semaphore < l.Capacity {
+		l.Semaphore++
+		l.SemaphoreLock.Unlock()
+		return l.lock(timeout)
+	} else {
+		l.SemaphoreLock.Unlock()
+		return int64(0)
+	}
+
+	return int64(0)
+}
+
+// increment id
+func (l *Lock) lock(timeout int) int64 {
+	id := atomic.AddInt64(&l.Id, 1)
+
+	l.TimeoutSetLock.Lock()
+	// increment the id each time
+	// impossible to get a collision
+	// so we don't need to check whether key exists
+	l.TimeoutSet[id] = true
+	l.TimeoutSetLock.Unlock()
+
+	time.AfterFunc(time.Duration(timeout)*time.Millisecond, func() {
+		l.Unlock(id)
+	})
+	return id
+}
+
+func (l *Lock) Unlock(id int64) bool {
+	l.TimeoutSetLock.Lock()
+	n := len(l.TimeoutSet)
+	delete(l.TimeoutSet, id)
+	deleted := n != len(l.TimeoutSet)
+	l.TimeoutSetLock.Unlock()
+
+	if deleted {
+		l.SemaphoreLock.Lock()
+		if l.Semaphore > 0 {
+			l.Semaphore--
+		}
+		count := l.Semaphore
+		if count == l.Capacity-1 {
+			l.SemaphoreLock.Unlock()
+			l.Cond.Broadcast()
+			return true
+		}
+		l.SemaphoreLock.Unlock()
+	}
+	return false
+}
+
+func (l *Lock) Resize(size int64) {
+	l.SemaphoreLock.Lock()
+	if l.Capacity != size {
+		l.Capacity = size
+	}
+	l.SemaphoreLock.Unlock()
+}

--- a/semaphore/semaphore.go
+++ b/semaphore/semaphore.go
@@ -52,16 +52,13 @@ func (g *Glock) CreateLock(key string, size int64) *Lock {
 		l.Resize(size)
 		g.LocksLock.Unlock()
 		return l
-	} else {
-		// lock still does not exist; let's create one
-		l := &Lock{Semaphore: int64(0), SemaphoreLock: sync.Mutex{}, Capacity: size, TimeoutSet: make(map[int64]bool), Id: int64(0), TimeoutSetLock: sync.Mutex{}}
-		l.Cond = sync.NewCond(&l.SemaphoreLock)
-		g.Locks[key] = l
-		g.LocksLock.Unlock()
-		return l
 	}
+	// lock still does not exist; let's create one
+	l := &Lock{Semaphore: int64(0), SemaphoreLock: sync.Mutex{}, Capacity: size, TimeoutSet: make(map[int64]bool), Id: int64(0), TimeoutSetLock: sync.Mutex{}}
+	l.Cond = sync.NewCond(&l.SemaphoreLock)
+	g.Locks[key] = l
 	g.LocksLock.Unlock()
-	return nil
+	return l
 }
 
 // note: no overflow on int64 - we will probably never get to the end of int64
@@ -100,11 +97,9 @@ func (l *Lock) NLock(timeout int) int64 {
 		l.Semaphore++
 		l.SemaphoreLock.Unlock()
 		return l.lock(timeout)
-	} else {
-		l.SemaphoreLock.Unlock()
-		return int64(0)
 	}
 
+	l.SemaphoreLock.Unlock()
 	return int64(0)
 }
 


### PR DESCRIPTION
this isn't done, but needs review. builds heavily on #24. diffs look bad, would recommend just checking out 

notes:
- tests inc.
- currently curl'able like (ignore auth if none): `curl -X PUT -d '{"key": "x", "timeout": 10000}' -H "Authorization: OAuth abcdefg" localhost:45625/lock` README should cover basics.
- do we want real OAuth? token generator? or just get a cert for https? This eliminates the authentication step and doesn't have persistent connections, just expects plaintext token in header for now on each request.
- client is broken (for now). re: curl
