### PR TITLE
stop logging every lock to disk, there's a debug log for it already

### DIFF
--- a/glock.go
+++ b/glock.go
@@ -60,7 +60,7 @@ func main() {
 	}
 
 	if config.Logging.Level == "" {
-		config.Logging.Level = "debug"
+		config.Logging.Level = "info"
 	}
 
 	listener, err := net.Listen("tcp", ":"+strconv.Itoa(config.Port))


### PR DESCRIPTION
causing issues with disks filling up over a long period of time