### PR TITLE
updates import path of stathat/consistent

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -14,8 +14,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/stathat/consistent"
 	"gopkg.in/inconshreveable/log15.v2"
+	"stathat.com/c/consistent"
 )
 
 type connectionError struct {


### PR DESCRIPTION
patrick moved this, it still compiles so the interface hasn't changed at least, hope it still works (seems likely). 
